### PR TITLE
Fixed New File Menu Item

### DIFF
--- a/init.xl.lua
+++ b/init.xl.lua
@@ -230,7 +230,7 @@ function RootView:on_mouse_pressed(button, x,y, clicks)
     return
   end
   local node = self.root_node:get_child_overlapping_point(x, y)
-  if node.hovered_scroll_button then
+  if node.hovered_scroll_button > 0 then
     node:scroll_tabs(node.hovered_scroll_button)
     return
   end

--- a/init.xl.lua
+++ b/init.xl.lua
@@ -230,7 +230,7 @@ function RootView:on_mouse_pressed(button, x,y, clicks)
     return
   end
   local node = self.root_node:get_child_overlapping_point(x, y)
-  if node.hovered_scroll_button > 0 then
+  if node.hovered_scroll_button then
     node:scroll_tabs(node.hovered_scroll_button)
     return
   end

--- a/treeview.lua
+++ b/treeview.lua
@@ -202,9 +202,11 @@ local has_fsutils, fsutils = core.try(require, "plugins.fsutils")
 
 if has_menu and has_fsutils then
   local function new_file_f(path)
-    -- lite does not allow opening inexistent files
-    error("This is not supported in lite")
-    command.perform "core:open-doc"
+    core.command_view:enter("New filename", function(name)
+      local doc = core.open_doc()
+      core.root_view:open_doc(doc)
+      doc:save(name)
+    end)
     core.command_view:set_text(path .. PATHSEP .. 'untitled')
   end
   

--- a/treeview.lua
+++ b/treeview.lua
@@ -203,7 +203,6 @@ local has_fsutils, fsutils = core.try(require, "plugins.fsutils")
 if has_menu and has_fsutils then
   local function new_file_f(path)
     command.perform "core:new-doc"
-    --core.command_view:set_text(path .. PATHSEP .. 'untitled')
   end
 
   local function new_file()

--- a/treeview.lua
+++ b/treeview.lua
@@ -205,7 +205,7 @@ if has_menu and has_fsutils then
     -- lite does not allow opening inexistent files
     error("This is not supported in lite")
     command.perform "core:open-doc"
-    core.command_view:set_text(path .. '/untitled')
+    core.command_view:set_text(path .. PATHSEP .. 'untitled')
   end
   
   local function new_file()
@@ -216,7 +216,7 @@ if has_menu and has_fsutils then
     core.command_view:enter("New directory name", function(dir)
       fsutils.mkdir(dir)
     end)
-    core.command_view:set_text(path .. "/New folder")
+    core.command_view:set_text(path .. PATHSEP .. "New folder")
   end
   
   local function new_dir()

--- a/treeview.lua
+++ b/treeview.lua
@@ -202,46 +202,42 @@ local has_fsutils, fsutils = core.try(require, "plugins.fsutils")
 
 if has_menu and has_fsutils then
   local function new_file_f(path)
-    core.command_view:enter("New filename", function(name)
-      local doc = core.open_doc()
-      core.root_view:open_doc(doc)
-      doc:save(name)
-    end)
-    core.command_view:set_text(path .. PATHSEP .. 'untitled')
+    command.perform "core:new-doc"
+    --core.command_view:set_text(path .. PATHSEP .. 'untitled')
   end
-  
+
   local function new_file()
     new_file_f(view.hovered_item.abs_filename)
   end
-  
+
   local function new_dir_f(path)
     core.command_view:enter("New directory name", function(dir)
       fsutils.mkdir(dir)
     end)
     core.command_view:set_text(path .. PATHSEP .. "New folder")
   end
-  
+
   local function new_dir()
     new_dir_f(view.hovered_item.abs_filename)
   end
-  
+
   local function delete_f(path)
     core.add_thread(function()
       local function wrap()
         return coroutine.wrap(function() fsutils.delete(path, true) end)
       end
-      
+
       for n in wrap() do
         if n % 100 == 0 then
           core.log("Deleted %d items.", n)
           coroutine.yield(0)
         end
       end
-      
+
       core.log("%q deleted.", path)
     end)
   end
-  
+
   local function delete()
     local path = view.hovered_item.abs_filename
     if view.hovered_item.type == "dir"
@@ -251,13 +247,13 @@ if has_menu and has_fsutils then
       delete_f(path)
     end
   end
-  
+
   local function dirname(path)
     local p = fsutils.split(path)
     table.remove(p)
     return table.concat(p, PATHSEP)
   end
-  
+
   local function rename()
     local oldname = view.hovered_item.abs_filename
     core.command_view:enter("Rename to", function(newname)
@@ -266,11 +262,11 @@ if has_menu and has_fsutils then
     end, common.path_suggest)
     core.command_view:set_text(dirname(oldname))
   end
-  
+
   local function copy_path()
     system.set_clipboard(view.hovered_item.abs_filename)
   end
-  
+
   menu:register(function() return view.hovered_item and view.hovered_item.type == "dir" end, {
     { text = "New file", command = new_file },
     { text = "New folder", command = new_dir },

--- a/treeview.xl.lua
+++ b/treeview.xl.lua
@@ -361,7 +361,11 @@ local has_fsutils, fsutils = core.try(require, "plugins.fsutils")
 if has_menu and has_fsutils then
   local function new_file()
     local path = view.hovered_item.abs_filename
-    command.perform "core:open-file"
+    core.command_view:enter("New filename", function(name)
+      local doc = core.open_doc()
+      core.root_view:open_doc(doc)
+      doc:save(name)
+    end)
     core.command_view:set_text(path .. PATHSEP .. 'untitled')
   end
   

--- a/treeview.xl.lua
+++ b/treeview.xl.lua
@@ -362,7 +362,7 @@ if has_menu and has_fsutils then
   local function new_file()
     local path = view.hovered_item.abs_filename
     command.perform "core:open-file"
-    core.command_view:set_text(path .. '/untitled')
+    core.command_view:set_text(path .. PATHSEP .. 'untitled')
   end
   
   local function new_dir()
@@ -370,7 +370,7 @@ if has_menu and has_fsutils then
     core.command_view:enter("New directory name", function(dir)
       fsutils.mkdir(dir)
     end)
-    core.command_view:set_text(path .. "/New folder")
+    core.command_view:set_text(path .. PATHSEP .. "New folder")
   end
   
   local function dirname(path)


### PR DESCRIPTION
As discussed in #4 , this pull

- Fixes an issue where new file menu item wasn't creating new files.
- Updates instances like ```"/NewFolder"``` to use ```PATHSEP.."NewFolder"``` instead.

Closes #4 